### PR TITLE
Add Robustness to Actual Face Detection

### DIFF
--- a/detect_face.py
+++ b/detect_face.py
@@ -9,38 +9,42 @@ FACE_CASCADE=cv2.CascadeClassifier(CASCADE)
 
 def detect_faces(image_path,display=True):
 
-	image=cv2.imread(image_path)
-	image_grey=cv2.cvtColor(image,cv2.COLOR_BGR2GRAY)
+    image=cv2.imread(image_path)
+    image_grey=cv2.cvtColor(image,cv2.COLOR_BGR2GRAY)
 
-	faces = FACE_CASCADE.detectMultiScale(image_grey,scaleFactor=1.16,minNeighbors=5,minSize=(25,25),flags=0)
+    faces = FACE_CASCADE.detectMultiScale(image_grey,scaleFactor=1.16,minNeighbors=5,minSize=(25,25),flags=0)
 
-	for x,y,w,h in faces:
-	    sub_img=image[y-10:y+h+10,x-10:x+w+10]
-	    os.chdir("Extracted")
-	    cv2.imwrite(str(randint(0,10000))+".jpg",sub_img)
-	    os.chdir("../")
-	    cv2.rectangle(image,(x,y),(x+w,y+h),(255, 255,0),2)
+    for x,y,w,h in faces:
+        sub_img=image[y-10:y+h+10,x-10:x+w+10]
+        os.chdir("Extracted")
+        try:
+            cv2.imwrite(str(randint(0,10000))+".jpg",sub_img)
+        except Exception:
+            continue
+        finally:
+            os.chdir("../")
+        cv2.rectangle(image,(x,y),(x+w,y+h),(255, 255,0),2)
 
-	if display:
-		cv2.imshow("Faces Found",image)
-		# if (cv2.waitKey(0) & 0xFF == ord('q')) or (cv2.waitKey(0) & 0xFF == ord('Q')):
-		# 	cv2.destroyAllWindows()
+    if display:
+        cv2.imshow("Faces Found",image)
+        # if (cv2.waitKey(0) & 0xFF == ord('q')) or (cv2.waitKey(0) & 0xFF == ord('Q')):
+        #     cv2.destroyAllWindows()
 
 if __name__ == "__main__":
-	
-	if not "Extracted" in os.listdir("."):
-		os.mkdir("Extracted")
     
-	if len(sys.argv) < 2:
-		print("Usage: python Detect_face.py 'image path'")
-		sys.exit()
+    if not "Extracted" in os.listdir("."):
+        os.mkdir("Extracted")
+    
+    if len(sys.argv) < 2:
+        print("Usage: python Detect_face.py 'image path'")
+        sys.exit()
 
-	if os.path.isdir(sys.argv[1]):
-		for image in os.listdir(sys.argv[1]):
-			try:
-				print ("Processing.....",os.path.abspath(os.path.join(sys.argv[1],image)))
-				detect_faces(os.path.abspath(os.path.join(sys.argv[1],image)),False)
-			except Exception:
-				print ("Could not process ",os.path.abspath(os.path.join(sys.argv[1],image)))
-	else:
-		detect_faces(sys.argv[1])
+    if os.path.isdir(sys.argv[1]):
+        for image in os.listdir(sys.argv[1]):
+            try:
+                print ("Processing.....",os.path.abspath(os.path.join(sys.argv[1],image)))
+                detect_faces(os.path.abspath(os.path.join(sys.argv[1],image)),False)
+            except Exception as e:
+                print ("Could not process ",os.path.abspath(os.path.join(sys.argv[1],image)), e)
+    else:
+        detect_faces(sys.argv[1])


### PR DESCRIPTION
Whenever the detect_faces function encounters an error inside the for loop, it might happen that it gets stuck in the wrong directory. As soon as the loop reaches the next iteration, it can't find the correct data since it is in the wrong directory. 

This PR introduces a try-except clause which makes sure, that it is inside the correct directors after every iteration.

Also, I fixed the indentation.